### PR TITLE
tracer: flag fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +189,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "derivative",
  "env_logger",
  "iced-x86",
  "jsonl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 clap = "2.33"
+derivative = "2.2"
 env_logger = "0.9"
 # TODO(ww): Stabilize once is_string_instruction has landed in a version
 iced-x86 = { git = "https://github.com/icedland/iced", rev = "c2944cd" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Result};
-use clap::{App, Arg, ArgGroup};
-
 use std::io::{stdout, Write};
 use std::process;
+
+use anyhow::{anyhow, Result};
+use clap::{App, Arg, ArgGroup};
 
 mod tiny86;
 mod trace;

--- a/src/tiny86.rs
+++ b/src/tiny86.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
-
 use std::io::Write;
+
+use anyhow::{anyhow, Result};
 
 use crate::trace::{MemoryHint, RegisterFile, Step};
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -55,10 +55,10 @@ trace-jsonls: $(TRACE_JSONLS)
 trace-texts: $(TRACE_TEXTS)
 
 %.trace.jsonl: %.elf
-	$(MTTN) -m32 -F jsonl ./$< > $@
+	$(MTTN) -t -m32 -F jsonl ./$< > $@
 
 %.trace.txt: %.elf
-	$(MTTN) -m32 -F tiny86-text ./$< > $@
+	$(MTTN) -t -m32 -F tiny86-text ./$< > $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Run the tracer in "strict" Tiny86 mode for tests.

Fixes #113.