### PR TITLE
tracer: initial syscall skeleton and kill(2) model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.58.1
+FROM rust:1.63.0
 
 RUN apt update && apt install -y nasm gdb gcc-multilib
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,14 @@ fn app() -> Command<'static> {
                 .long("tiny86-only"),
         )
         .arg(
+            Arg::new("syscall-model")
+                .help("For Tiny86: which syscall model to use when emulating syscalls")
+                .long("syscall-model")
+                .possible_values(&["decree", "linux32"])
+                .default_value("decree")
+                .requires("tiny86-only")
+        )
+        .arg(
             Arg::new("debug-on-fault")
                 .help("Suspend the tracee and detach if a memory access faults")
                 .short('d')

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn app() -> Command<'static> {
                 .long("syscall-model")
                 .possible_values(&["decree", "linux32"])
                 .default_value("decree")
-                .requires("tiny86-only")
+                .requires("tiny86-only"),
         )
         .arg(
             Arg::new("debug-on-fault")

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -1,0 +1,3 @@
+//! Syscall models for mttn.
+//!
+//! These are only used in "Tiny86" tracing mode.

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -34,7 +34,7 @@ impl CommandPersonality for Command {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
 #[repr(u8)]
 pub enum DecreeSyscall {
     Terminate = 1,
@@ -68,7 +68,7 @@ impl TryFrom<u32> for DecreeSyscall {
 /// All `mttn` memory operations are 1, 2, 4, or 8 bytes.
 /// Larger operations are either modeled as multiple individual operations
 /// (if caused by a `REP` prefix), ignored (if configured), or cause a fatal error.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[repr(u8)]
 pub enum MemoryMask {
     Byte,
@@ -116,7 +116,7 @@ impl TryFrom<Register> for MemoryMask {
 /// perform a read-and-update are modeled with two separate operations.
 /// Instructions that perform conditional reads or writes are modeled only
 /// if the conditional memory operation actually took place during the trace.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[repr(u8)]
 pub enum MemoryOp {
     Read,
@@ -125,7 +125,7 @@ pub enum MemoryOp {
 
 /// Represents an entire traced memory operation, including its kind (`MemoryOp`),
 /// size (`MemoryMask`), concrete address, and actual read or written data.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct MemoryHint {
     pub address: u64,
     pub operation: MemoryOp,
@@ -136,7 +136,7 @@ pub struct MemoryHint {
 /// Represents an individual step in the trace, including the raw instruction bytes,
 /// the register file state before execution, and any memory operations that result
 /// from execution.
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Step {
     pub instr: Vec<u8>,
     pub regs: RegisterFile,
@@ -149,7 +149,7 @@ pub struct Step {
 ///
 /// Other registers are tracked as an implementation detail, but are not
 /// recorded in each trace step.
-#[derive(Clone, Copy, Debug, Default, Derivative, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Derivative, PartialEq, Eq, Serialize)]
 pub struct RegisterFile {
     pub rax: u64,
     pub rbx: u64,

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -661,7 +661,11 @@ impl<'a> Tracee<'a> {
         })
     }
 
-    fn tracee_hints_stage1(&mut self, instr: &Instruction, hints: &mut Vec<MemoryHint>) -> Result<()> {
+    fn tracee_hints_stage1(
+        &mut self,
+        instr: &Instruction,
+        hints: &mut Vec<MemoryHint>,
+    ) -> Result<()> {
         log::debug!("memory hints stage 1");
         let info = self
             .info_factory

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -469,7 +469,7 @@ impl<'a> Tracee<'a> {
             //    then phase 2).
             ptrace::step(self.tracee_pid, None)?;
 
-            if instr.is_string_instruction() {
+            if instr.is_string_instruction() || instr.is_stack_instruction() {
                 // NOTE(ww): By default, recent-ish x86 CPUs execute MOVS and STOS
                 // in "fast string operation" mode. This can cause stores to not appear
                 // when we expect them to, since they can be executed out-of-order.
@@ -909,6 +909,7 @@ mod tests {
         Tracer {
             ignore_unsupported_memops: false,
             tiny86_only: false,
+            decree_syscalls: false,
             debug_on_fault: false,
             disable_aslr: true,
             bitness: 32,

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,7 +17,8 @@ ASM_TESTS := \
 	rol \
 	jmp \
 	push_pop \
-	push_pop2
+	push_pop2 \
+	tinysyscall
 
 C_TESTS := \
 	seteip \
@@ -61,11 +62,13 @@ trace-jsonls: $(TRACE_JSONLS)
 .PHONY: trace-texts
 trace-texts: $(TRACE_TEXTS)
 
+.DELETE_ON_ERROR:
 %.trace.jsonl: %.elf
-	$(MTTN) -At -m32 -F jsonl ./$< > $@
+	$(MTTN) -At --syscall-model=decree -m32 -F jsonl ./$< > $@
 
+.DELETE_ON_ERROR:
 %.trace.txt: %.elf
-	$(MTTN) -At -m32 -F tiny86-text ./$< > $@
+	$(MTTN) -At --syscall-model=decree -m32 -F tiny86-text ./$< > $@
 
 .PHONY: clean
 clean:

--- a/test/tinysyscall.s
+++ b/test/tinysyscall.s
@@ -1,0 +1,8 @@
+section .text
+global _start
+
+_start:
+  ; exit
+  mov eax, 1
+  mov ebx, 42
+  int 0x80

--- a/test/tinysyscall.s
+++ b/test/tinysyscall.s
@@ -6,3 +6,8 @@ _start:
   mov eax, 1
   mov ebx, 42
   int 0x80
+
+  ; exit
+  mov eax, 1
+  mov ebx, 42
+  int 0x80


### PR DESCRIPTION
This adds the initial scaffolding for syscall support, including an initial syscall model for the DECREE-style `terminate(2)` (i.e. `kill(2)`) syscall.